### PR TITLE
Utm zone bugfix

### DIFF
--- a/buteo/utils/utils_projection.py
+++ b/buteo/utils/utils_projection.py
@@ -10,6 +10,7 @@ from typing import Union, List
 import osgeo
 from osgeo import gdal, ogr, osr
 import numpy as np
+import math
 
 # Internal
 from buteo.utils import utils_gdal
@@ -578,11 +579,11 @@ def _get_utm_zone_from_latlng(
     """
     assert isinstance(latlng, (list, np.ndarray)), "latlng must be in the form of a list."
 
-    zone = round(((latlng[1] + 180) / 6) + 1)
+    zone = math.floor(((latlng[1] + 180) / 6) + 1)
     n_or_s = "S" if latlng[0] < 0 else "N"
 
     false_northing = "10000000" if n_or_s == "S" else "0"
-    central_meridian = str(round(((zone * 6) - 180) - 3))
+    central_meridian = str(zone * 6 - 183)
     epsg = f"32{'7' if n_or_s == 'S' else '6'}{str(zone)}"
 
     if return_epsg:

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -153,18 +153,18 @@ def test_get_utm_zone_from_latlng():
     for long in longitudes:
         for lat in latitudes:
             if long < -6:
-                zone = '30'
+                zone = '29'
             elif long >= -6 and 0 > long:
-                zone = '31'
+                zone = '30'
             elif long >= 0 and 6 > long:
-                zone = '32'
+                zone = '31'
             elif long >= 6:
-                zone = '33'
+                zone = '32'
             if lat >= 0:
                 ns = '6'
             else:
                 ns = '7'
 
             epsg = utils_projection._get_utm_zone_from_latlng([lat,long],return_epsg=True)
-            assert epsg.lower() == f'32{ns}{zone}', "UTM zone for latlong point is wrong."
+            assert epsg.lower() == f'32{ns}{zone}', f"UTM zone for latlong point is wrong {lat}, {long}."
                 

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -10,7 +10,7 @@ from osgeo import gdal, osr
 # Internal
 from utils_tests import create_sample_raster
 from buteo.raster.reproject import raster_reproject, _find_common_projection, _raster_reproject
-
+from buteo.utils import utils_projection
 
 
 def test_match_raster_projections_same_projection():
@@ -145,3 +145,26 @@ def test_raster_reproject_dtype():
 
     raster_band = reprojected_raster.GetRasterBand(1)
     assert raster_band.DataType == gdal.GDT_Int32, "Data type is not set correctly."
+
+def test_get_utm_zone_from_latlng():
+    longitudes = [-7,-6,-3,-1,0,1,3,6,7]
+    latitudes = [-1,0,1]
+
+    for long in longitudes:
+        for lat in latitudes:
+            if long < -6:
+                zone = '30'
+            elif long >= -6 and 0 > long:
+                zone = '31'
+            elif long >= 0 and 6 > long:
+                zone = '32'
+            elif long >= 6:
+                zone = '33'
+            if lat >= 0:
+                ns = '6'
+            else:
+                ns = '7'
+
+            epsg = utils_projection._get_utm_zone_from_latlng([lat,long],return_epsg=True)
+            assert epsg.lower() == f'32{ns}{zone}', "UTM zone for latlong point is wrong."
+                


### PR DESCRIPTION
Corrects rounding error in UTM zone calculations for [`utils_projections._get_utm_zone_from_latlng`](https://github.com/aliFrancis/buteo/blob/94a122dea039ab592d819a2ef8256380361a7dd8/buteo/utils/utils_projection.py#L560C1-L561C1)

Previously, longitudinal zones calculated with `round`. Caused boundaries of zones to occur at meridians  (3°E, 9°E, etc.), rather than their true edges (0°E, 6°E, etc.). Using `math.floor` solves this issue.

Added tests in test_reproject.py to check EPSG code is outputted correctly. Tests do not cover the Wkt format that can also be outputted by `_get_utm_zone_from_latlng`
